### PR TITLE
fix(flakectl): build hashed packages before fixing hashes

### DIFF
--- a/modules/flake/apps.nix
+++ b/modules/flake/apps.nix
@@ -18,6 +18,7 @@
           flake = self.outPath;
           cache = "https://mirkolenz.cachix.org";
           build-path = "checks.${system}";
+          hash-path = "custom.hashedPackages";
           update-path = "custom.flattenedPackages";
         };
         home-manager.program = pkgs.writeShellScriptBin "home-manager" /* bash */ ''

--- a/pkgs/by-name/flakectl/script.py
+++ b/pkgs/by-name/flakectl/script.py
@@ -36,6 +36,7 @@ class Config:
     cache: str | None
     impure_attr: str | None
     build_path: str | None
+    hash_path: str | None
     update_path: str | None
     max_workers: int
 
@@ -190,6 +191,7 @@ def main(
     cache: Annotated[str | None, typer.Option()] = None,
     impure_attr: Annotated[str | None, typer.Option()] = None,
     build_path: Annotated[str | None, typer.Option()] = None,
+    hash_path: Annotated[str | None, typer.Option()] = None,
     update_path: Annotated[str | None, typer.Option()] = None,
     max_workers: Annotated[int, typer.Option()] = 8,
 ):
@@ -349,9 +351,15 @@ def update_flake(
             )
         )
 
-    # nixd reads the working tree, so unlike `cfg.flake` it sees the lockfile
-    # rewritten above. Not fatal: it also exits non-zero when there is no hash to
-    # fix, and one it could not repair still fails the PR's own checks.
+    if cfg.hash_path:
+        # `fix hashes` repairs what nix journaled while building, so the build is
+        # what gives it anything to do and its failure is the point. `.` re-resolves
+        # the working tree; `cfg.flake` predates the lockfile rewritten above.
+        hashed = nix_eval_dict(cfg.nix_exe, f".#{cfg.hash_path}")
+        refs = [f'.#"{name}"' for name in hashed]
+        run_logged(nix_argv(cfg.nix_exe, "build", "--no-link", *refs), check=False)
+
+    # Non-zero also means "nothing to fix".
     run_logged([cfg.nixd_exe, "fix", "hashes", "--auto-apply"], check=False)
 
     if commit:

--- a/pkgs/by-name/flakectl/script.py
+++ b/pkgs/by-name/flakectl/script.py
@@ -290,14 +290,12 @@ def require_worktree(flake: str) -> None:
     its flake.nix matches the one here exactly when this is its working copy —
     dirty included, since `nix run .` snapshots uncommitted edits too.
     """
+    target = Path("flake.nix")
     source = Path(flake) / "flake.nix"
 
-    if not source.is_file():
-        return
-
-    target = Path("flake.nix")
-
-    if not target.is_file() or source.read_bytes() != target.read_bytes():
+    if not target.is_file() or (
+        source.is_file() and source.read_bytes() != target.read_bytes()
+    ):
         typer.echo("Not this flake's working copy; run from a checkout.", err=True)
         raise typer.Exit(1)
 
@@ -317,16 +315,6 @@ def commit_pkgs(git_exe: str, message: str) -> None:
 @app.command("update-flake")
 def update_flake(
     ctx: typer.Context,
-    flake_file: Annotated[
-        Path,
-        typer.Argument(
-            exists=True,
-            file_okay=True,
-            dir_okay=False,
-            readable=True,
-            writable=True,
-        ),
-    ] = Path("flake.nix"),
     dry_run: Annotated[bool, typer.Option("--dry-run", "-n")] = False,
     commit: Annotated[bool, typer.Option("--commit", "-c")] = False,
     update: Annotated[bool, typer.Option("--update", "-u")] = True,
@@ -334,6 +322,7 @@ def update_flake(
     """Update flake.nix github inputs and lockfile; refresh pinned hashes."""
     cfg: Config = ctx.obj
     require_worktree(cfg.flake)
+    flake_file = Path("flake.nix")
     content = flake_file.read_text()
     new_content = GITHUB_SEMVER_REF.sub(
         lambda m: replace_github_ref(cfg.gh_exe, m), content

--- a/pkgs/by-name/flakectl/script.py
+++ b/pkgs/by-name/flakectl/script.py
@@ -282,6 +282,26 @@ def replace_github_ref(gh_exe: str, match: re.Match[str]) -> str:
     return f'url = "github:{owner}/{repo}/{latest}"'
 
 
+def require_worktree(flake: str) -> None:
+    """Refuse to edit a checkout that is not the flake we were resolved from.
+
+    `nix run github:mirkolenz/infra -- update-…` would otherwise rewrite whatever
+    repo happens to be the cwd. `flake` is a store snapshot of our own source, so
+    its flake.nix matches the one here exactly when this is its working copy —
+    dirty included, since `nix run .` snapshots uncommitted edits too.
+    """
+    source = Path(flake) / "flake.nix"
+
+    if not source.is_file():
+        return
+
+    target = Path("flake.nix")
+
+    if not target.is_file() or source.read_bytes() != target.read_bytes():
+        typer.echo("Not this flake's working copy; run from a checkout.", err=True)
+        raise typer.Exit(1)
+
+
 def commit_pkgs(git_exe: str, message: str) -> None:
     """Commit anything that changed under pkgs/, if anything did."""
     status = subprocess_stdout([git_exe, "status", "--porcelain", "--", "pkgs/"])
@@ -313,6 +333,7 @@ def update_flake(
 ):
     """Update flake.nix github inputs and lockfile; refresh pinned hashes."""
     cfg: Config = ctx.obj
+    require_worktree(cfg.flake)
     content = flake_file.read_text()
     new_content = GITHUB_SEMVER_REF.sub(
         lambda m: replace_github_ref(cfg.gh_exe, m), content
@@ -525,6 +546,7 @@ def update_pkgs(
 ):
     """Run each package's `passthru.updateScript` to refresh sources, in parallel."""
     cfg: Config = ctx.obj
+    require_worktree(cfg.flake)
 
     if cfg.update_path is None or cfg.update_scripts_nix is None:
         typer.echo(

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -30,6 +30,10 @@ let
   custom = {
     # flat derivations exposed via flake.packages and built in CI
     flattenedPackages = lib.filterAttrs (_: lib.isDerivation) (byName // flattenedScopes // overrides);
+    # derivations with an in-tree hash, built by `update-flake` so it can fix them
+    hashedPackages = {
+      inherit (final) caddy-custom;
+    };
   };
 in
 # overlay layers, ordered low -> high precedence (mergeAttrsList lets later entries win)


### PR DESCRIPTION
Follow-up to #675, which did not fix the problem.

## What went wrong

`determinate-nixd fix hashes` repairs mismatches Determinate Nix **journaled while building** — it does not scan the tree. The first update run after #675 merged said so plainly ([run 30159463548](https://github.com/mirkolenz/infra/actions/runs/30159463548/job/89682298639)):

```
determinate-nixd fix hashes --auto-apply
No hash mismatches have been encountered recently.
```

So the `build_uncached(..., check=False)` that #675 removed was not an optimisation — it was the *producer* of the record `fix hashes` consumes. #675 removed the producer and kept the consumer. That also explains the `run_fix_hashes = bool(uncached)` gate it deleted: that was "only bother consuming if we attempted a build that could have journaled something", not a cost check.

## The fix

Restore the build, targeting `.`:

```python
hashed = nix_eval_dict(cfg.nix_exe, f".#{cfg.hash_path}")
run_logged(
    nix_argv(cfg.nix_exe, "build", "--no-link", *(f'.#"{name}"' for name in hashed)),
    check=False,
)
```

`.` re-resolves the working tree at call time, so it sees the lockfile rewritten a few lines above. `cfg.flake` cannot: it is pinned when `nix run` resolves the wrapper, which is what made the original probe answer for the packages the update had just replaced. `cfg.flake` stays the reference for `build-config` and `build-pkgs`, which need a snapshot that still works when flakectl is invoked via `github:mirkolenz/infra`.

The build tolerates failure on purpose — the mismatch *is* what we are here to fix.

`--hash-path` and `custom.hashedPackages` come back, the latter now carrying a comment about why it exists.

## Not restored

The binary-cache pre-filter that used to wrap the build. Substitution already makes the build cheap while the pinned hashes are correct, and the filter was the part that went stale. `cached_paths` / `path_in_cache` remain in use by `build-pkgs`.

## Verification

`ruff format --check` and `ruff check` pass. Nix was not available in the environment this was written in, so the invocations have not been executed locally — but both are the shapes that worked before #675, with `.` substituted for the pinned store path, and the original CI logs show that form resolving (`path:/nix/store/…-source#"caddy-custom"`).

A run of `update.yaml` on this branch should show: the caddy build failing on the hash mismatch, `fix hashes` applying `sha256-7GoH8YLCoPmPExQxoga2FHB58zQDoZVf1BBwkVi0SsQ=`, and a `chore(deps/pkgs): hashing` commit. `caddy-custom.nix` is deliberately untouched here so that path actually gets exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eeUBnU3gpKKiKcdCdTMTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_013eeUBnU3gpKKiKcdCdTMTJ)_