### PR TITLE
fix(nix): allow shallow clones in the non-flake entry point

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,8 @@
   ...
 }:
 let
-  flake = builtins.getFlake ("git+file://" + toString ./.);
+  # `shallow=1` skips `revCount`, which a shallow clone cannot provide.
+  flake = builtins.getFlake ("git+file://" + toString ./. + "?shallow=1");
   # Import `./pkgs` directly rather than the flake's store-copied
   # `overlays.default`, so `meta.position` stays in the working tree and
   # updateScripts can edit package files in place.


### PR DESCRIPTION
The update workflow checks out with depth 1 and commits the refreshed
lockfile, leaving a clean shallow working tree. `builtins.getFlake` on a
clean git+file workdir computes `revCount`, which a shallow repository
cannot provide, so the post-update evaluation check aborted with
"is a shallow Git repository, so 'revCount' is not available".

Pass `shallow=1` so the fetcher skips `revCount`; no expression in this
repo reads it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KhoiygGrxJCpX4g3oCtozd